### PR TITLE
clean out unused tp functions

### DIFF
--- a/Python/firms/main.py
+++ b/Python/firms/main.py
@@ -35,23 +35,23 @@ T           = integer > S, number of time periods until steady state
 alpha       = scalar in (0,1), expenditure share on good 1
 c1til       = scalar > 0, minimum consumption of good 1
 c2til       = scalar > 0, minimum consumption of good 2
-cmtilvec    = [2,] vector, minimum consumption values for all goods
+cm_tilde    = [2,] vector, minimum consumption values for all goods
 beta_ann    = scalar in [0,1), discount factor for one year
 beta        = scalar in [0,1), discount factor for each model period
 sigma       = scalar > 0, coefficient of relative risk aversion
 nvec        = [S,] vector, exogenous labor supply n_{s,t}
 A1          = scalar > 0, total factor productivity in industry 1
 A2          = scalar > 0, total factor productivity in industry 2
-Avec        = [2,] vector, total factor productivity values for all
+A        = [2,] vector, total factor productivity values for all
               industries
 gam1        = scalar in (0,1), capital share of income in industry 1
 gam2        = scalar in (0,1), capital share of income in industry 2
-gamvec      = [2,] vector, capital shares of income for all industries
+gamma      = [2,] vector, capital shares of income for all industries
 eps1        = scalar in (0,1), elasticity of substitution between
               capital and labor in industry 1
 eps2        = scalar in (0,1), elasticity of substitution between
               capital and labor in industry 2
-epsvec      = [2,] vector, elasticities of substitution between capital
+epsilon      = [2,] vector, elasticities of substitution between capital
               and labor for all industries
 del1_ann    = scalar in [0,1], one-year depreciation rate of capital in
               industry 1
@@ -61,7 +61,7 @@ del2_ann    = scalar in [0,1], one-year depreciation rate of capital in
               industry 2
 del2        = scalar in [0,1], model period depreciation rate of capital
               in industry 2
-delvec      = [2,] vector, model period depreciation rates for all
+delta      = [2,] vector, model period depreciation rates for all
               industries
 ss_tol      = scalar > 0, tolerance level for steady-state fsolve
 ss_graphs   = boolean, =True if want graphs of steady-state objects
@@ -80,7 +80,7 @@ T = 220
 alpha = 0.4
 c1til = 0.6
 c2til = 0.6
-cmtilvec = np.array([c1til, c2til])
+cm_tilde = np.array([c1til, c2til])
 beta_annual = 0.96
 beta = beta_annual ** (80 / S)
 sigma = 3.0
@@ -90,18 +90,18 @@ nvec[int(round(2 * S / 3)):] = 0.9
 # Firm parameters
 A1 = 1.
 A2 = 1.2
-Avec = np.array([A1, A2])
+A = np.array([A1, A2])
 gam1 = 0.15
 gam2 = 0.2
-gamvec = np.array([gam1, gam2])
+gamma = np.array([gam1, gam2])
 eps1 = 0.6
 eps2 = 0.6
-epsvec = np.array([eps1, eps2])
+epsilon = np.array([eps1, eps2])
 del1_ann = .04
 del1 = 1 - ((1-del1_ann) ** (80 / S))
 del2_ann = .05
 del2 = 1 - ((1-del2_ann) ** (80 / S))
-delvec = np.array([del1, del2])
+delta = np.array([del1, del2])
 # SS parameters
 ss_tol = 1e-13
 ss_graphs = False
@@ -126,7 +126,7 @@ feas_params  = length 5 tuple, parameters for feasible function:
 b_guess      = [S-1,] vector, initial guess for savings to use in fsolve
                in ssf.get_cbess
 GoodGuess    = boolean, =True if initial steady-state guess is feasible
-r_cstr_ss    = boolean, =True if initial r + delvec <= 0
+r_cstr_ss    = boolean, =True if initial r + delta <= 0
 w_cstr_ss    = boolean, =True if initial w <= 0
 c_cstr_ss    = [S,] boolean vector, =True if c_s<=0 for initial r and w
 cm_cstr_ss   = [2, S] boolean matrix, =True if c_{m,s}<=0 for initial r
@@ -165,13 +165,13 @@ b_guess[:int(round(2 * S / 3))] = \
 b_guess[int(round(2 * S / 3)):] = \
     (np.linspace(0.3, 0.003, S - 1 - int(round(2 * S / 3))))
 GoodGuess, r_cstr_ss, w_cstr_ss, c_cstr_ss, cm_cstr_ss, K1K2_cstr_ss \
-    = ssf.feasible(feas_params, rwbar_init, b_guess, cmtilvec, Avec,
-    gamvec, epsvec, delvec, nvec)
+    = ssf.feasible(feas_params, rwbar_init, b_guess, cm_tilde, A,
+    gamma, epsilon, delta, nvec)
 
 if r_cstr_ss == True and w_cstr_ss == True:
-    print 'Initial guess is not feasible because both r + delvec, w <= 0.'
+    print 'Initial guess is not feasible because both r + delta, w <= 0.'
 elif r_cstr_ss == True and w_cstr_ss == False:
-    print 'Initial guess is not feasible because r + delvec <= 0.'
+    print 'Initial guess is not feasible because r + delta <= 0.'
 elif r_cstr_ss == False and w_cstr_ss == True:
     print 'Initial guess is not feasible because w <= 0.'
 elif (r_cstr_ss == False and w_cstr_ss == False and c_cstr_ss.max() == 1
@@ -197,8 +197,8 @@ elif GoodGuess == True:
     ss_params = (S, alpha, beta, sigma, ss_tol)
     (r_ss, w_ss, pm_ss, p_ss, b_ss, c_ss, cm_ss, eul_ss, Cm_ss, Ym_ss,
         Km_ss, Lm_ss, MCK_err_ss, MCL_err_ss, ss_time) = \
-        ssf.SS(ss_params, rwbar_init, b_guess, cmtilvec, Avec,
-        gamvec, epsvec, delvec, nvec, ss_graphs)
+        ssf.SS(ss_params, rwbar_init, b_guess, cm_tilde, A,
+        gamma, epsilon, delta, nvec, ss_graphs)
 
     # Print diagnostics
     print 'The maximum absolute steady-state Euler error is: ', \
@@ -217,7 +217,7 @@ elif GoodGuess == True:
     print pm_ss, p_ss
     print 'Aggregate output, capital stock and consumption for each industry are:'
     print np.array([[Ym_ss], [Km_ss], [Cm_ss]])
-    rcmdiff_ss = Ym_ss - Cm_ss - delvec * Km_ss
+    rcmdiff_ss = Ym_ss - Cm_ss - delta * Km_ss
     print 'The difference Ym_ss - Cm_ss - delta_m * Km_ss is: ', rcmdiff_ss
 
     # Print SS computation time
@@ -335,7 +335,7 @@ elif GoodGuess == True:
 
             guesses = np.append(rpath_init[:T], wpath_init[:T])
             solutions = opt.fsolve(tpf.TPI_fsolve, guesses, args=(tpi_params, Km_ss, Ym_ss,
-               Gamma1, cmtilvec, Avec, gamvec, epsvec, delvec, nvec,
+               Gamma1, cm_tilde, A, gamma, epsilon, delta, nvec,
                tpi_graphs), xtol=1e-9, col_deriv=1)
             rpath = solutions[:T].reshape(T)
             wpath = solutions[T:].reshape(T)
@@ -382,13 +382,13 @@ elif GoodGuess == True:
                 eul_path, Cm_path, Ym_path, Km_path, Lm_path,
                 MCKerr_path, MCLerr_path, tpi_time) = \
                 tpf.TP(tpi_params, rpath, wpath, Km_ss, Ym_ss,
-                Gamma1, cmtilvec, Avec, gamvec, epsvec, delvec, nvec,
+                Gamma1, cm_tilde, A, gamma, epsilon, delta, nvec,
                 tpi_graphs)
 
 
             # Print diagnostics
             print 'The max. absolute difference in the resource constraints are:'
-            delmat = np.tile(delvec.reshape((2, 1)), T-2)
+            delmat = np.tile(delta.reshape((2, 1)), T-2)
             ResmDiff = (Ym_path[:, :T-2] - Cm_path[:, :T-2] - Km_path[:, 1:T-1] +
                       (1 - delmat) * Km_path[:, :T-2])
             print np.absolute(ResmDiff).max(axis=1)

--- a/Python/firms/main.py
+++ b/Python/firms/main.py
@@ -332,12 +332,6 @@ elif GoodGuess == True:
             # Run TPI
             tpi_params = (S, T, alpha, beta, sigma, r_ss, w_ss,
                          maxiter_tpi, mindist_tpi, xi_tpi, tpi_tol)
-            # (r_path, w_path, pm_path, p_path, b_path, c_path, cm_path,
-            #     eul_path, Cm_path, Ym_path, Km_path, Lm_path,
-            #     MCKerr_path, MCLerr_path, tpi_time) = \
-            #     tpf.TPI(tpi_params, rpath_init, wpath_init, Km_ss, Ym_ss,
-            #     Gamma1, cmtilvec, Avec, gamvec, epsvec, delvec, nvec,
-            #     tpi_graphs)
 
             guesses = np.append(rpath_init[:T], wpath_init[:T])
             solutions = opt.fsolve(tpf.TPI_fsolve, guesses, args=(tpi_params, Km_ss, Ym_ss,
@@ -387,7 +381,7 @@ elif GoodGuess == True:
             (r_path, w_path, pm_path, p_path, b_path, c_path, cm_path,
                 eul_path, Cm_path, Ym_path, Km_path, Lm_path,
                 MCKerr_path, MCLerr_path, tpi_time) = \
-                tpf.TPI(tpi_params, rpath, wpath, Km_ss, Ym_ss,
+                tpf.TP(tpi_params, rpath, wpath, Km_ss, Ym_ss,
                 Gamma1, cmtilvec, Avec, gamvec, epsvec, delvec, nvec,
                 tpi_graphs)
 

--- a/Python/firms/tpfuncs.py
+++ b/Python/firms/tpfuncs.py
@@ -416,78 +416,8 @@ def get_Cmpath(cmpath):
     return Cmpath
 
 
-def get_Ympath(params, rpath, wpath, Ym_ss, Cmpath, Avec, gamvec,
-  epsvec, delvec):
-    '''
-    Generate matrix (vectors) of time path of aggregate output Y_{m,t}
-    by industry given r_t, w_t, and C_{m,t}
-    '''
-    T, r_ss, w_ss = params
-    Ympath = np.zeros(Cmpath.shape)
-    rtp1 = r_ss
-    wtp1 = w_ss
-    Ymtp1 = Ym_ss
-    aa = gamvec
-    bb = 1 - gamvec
-    cc = (1 - gamvec) / gamvec
-    dd = 1 / epsvec
-    ee = epsvec -1
-    ff = (epsvec - 1) / epsvec
-    gg = epsvec / (1 - epsvec)
 
-    for t in range(T, 0, -1): # Go from periods T to 1
-        hh = (rtp1 + delvec) / wtp1
-        ii = (rpath[t-1] + delvec) / wpath[t-1]
-        numerator = Cmpath[:,t-1] + (Ymtp1 / Avec) * (((aa ** dd) +
-                    (bb ** dd) * (hh ** ee) * (cc ** ff)) ** gg)
-        denominator = 1 + ((1 - delvec) / Avec) * (((aa ** dd) +
-                    (bb ** dd) * (ii ** ee) * (cc ** ff)) ** gg)
-        Ymt = numerator / denominator
-        Ympath[:, t-1] = Ymt
-        Ytp1 = Ymt
-        rtp1 = rpath[t-1]
-        wtp1 = wpath[t-1]
-
-    return Ympath
-
-def get_Ympath_alt(params, rpath, wpath, Km_ss, Cmpath, Avec, gamvec,
-  epsvec, delvec):
-    '''
-    Generate matrix (vectors) of time path of aggregate output Y_{m,t}
-    by industry given r_t, w_t, and C_{m,t}
-    '''
-    T, r_ss, w_ss = params
-    Ympath = np.zeros(Cmpath.shape)
-    rtp1 = r_ss
-    wtp1 = w_ss
-    Kmtp1 = Km_ss
-    aa = gamvec
-    bb = 1 - gamvec
-    cc = (1 - gamvec) / gamvec
-    dd = 1 / epsvec
-    ee = epsvec -1
-    ff = (epsvec - 1) / epsvec
-    gg = epsvec / (1 - epsvec)
-
-    for t in range(T, 0, -1): # Go from periods T to 1
-        hh = (rtp1 + delvec) / wtp1
-        ii = (rpath[t-1] + delvec) / wpath[t-1]
-        numerator = Cmpath[:,t-1] + Kmtp1
-        denominator = 1 + ((1 - delvec) / Avec) * (((aa ** dd) +
-                    (bb ** dd) * (ii ** ee) * (cc ** ff)) ** gg)
-        Ymt = numerator / denominator
-        Ympath[:, t-1] = Ymt
-        Kmt =  (Ymt/Avec) * (((aa ** dd) +
-                    (bb ** dd) * (ii ** ee) * (cc ** ff)) ** gg)
-        Ytp1 = Ymt
-        Kmtp1 = Kmt
-        rtp1 = rpath[t-1]
-        wtp1 = wpath[t-1]
-
-    return Ympath
-
-
-def get_YKmpath2(params, rpath, wpath, Km_ss, Cmpath, Avec, gamvec,
+def get_YKmpath(params, rpath, wpath, Km_ss, Cmpath, Avec, gamvec,
   epsvec, delvec):
     '''
     Generate matrix (vectors) of time path of aggregate output Y_{m,t}
@@ -510,6 +440,7 @@ def get_YKmpath2(params, rpath, wpath, Km_ss, Cmpath, Avec, gamvec,
     for t in range(T, 0, -1): # Go from periods T to 1
         hh = (rtp1 + delvec) / wtp1
         ii = (rpath[t-1] + delvec) / wpath[t-1]
+
         numerator = Cmpath[:,t-1] + Kmtp1
         denominator = 1 + ((1 - delvec) / Avec) * (((aa ** dd) +
                     (bb ** dd) * (ii ** ee) * (cc ** ff)) ** gg)
@@ -526,130 +457,8 @@ def get_YKmpath2(params, rpath, wpath, Km_ss, Cmpath, Avec, gamvec,
     return Ympath, Kmpath
 
 
-def get_Kmpath(Ympath, rpath, wpath, Avec, gamvec, epsvec, delvec):
-    '''
-    Generates vector of aggregate output Y_m of good m and capital
-    demand K_m for good m given r and w
 
-    Inputs:
-        rpath  = [T+S-2] vector, time path of interest rates
-        wpath  = scalar > 0, real wage
-        Cmvec  = [2,] vector, aggregate consumption of all goods
-        pmvec  = [2,] vector, prices in each industry
-        Avec   = [2,] vector, total factor productivity values for all
-                 industries
-        gamvec = [2,] vector, capital shares of income for all
-                 industries
-        epsvec = [2,] vector, elasticities of substitution between
-                 capital and labor for all industries
-        delvec = [2,] vector, model period depreciation rates for all
-                 industries
-
-    Functions called: None
-
-    Objects in function:
-        aa    = [2,] vector, gamvec
-        bb    = [2,] vector, 1 - gamvec
-        cc    = [2,] vector, (1 - gamvec) / gamvec
-        dd    = [2,] vector, (r + delvec) / w
-        ee    = [2,] vector, 1 / epsvec
-        ff    = [2,] vector, (epsvec - 1) / epsvec
-        gg    = [2,] vector, epsvec - 1
-        hh    = [2,] vector, epsvec / (1 - epsvec)
-        ii    = [2,] vector, ((1 / Avec) * (((aa ** ee) + (bb ** ee) *
-                (cc ** ff) * (dd ** gg)) ** hh))
-        Ymvec = [2,] vector, aggregate output of all industries
-        Kmvec = [2,] vector, capital demand of all industries
-
-    Returns: Kmpath
-    '''
-    aa1 = gamvec[0]
-    aa2 = gamvec[1]
-    bb1 = 1 - gamvec[0]
-    bb2 = 1 - gamvec[1]
-    cc1 = (1 - gamvec[0]) / gamvec[0]
-    cc2 = (1 - gamvec[1]) / gamvec[1]
-    dd1 = (rpath + delvec[0]) / wpath
-    dd2 = (rpath + delvec[1]) / wpath
-    ee1 = 1 / epsvec[0]
-    ee2 = 1 / epsvec[1]
-    ff1 = (epsvec[0] - 1) / epsvec[0]
-    ff2 = (epsvec[1] - 1) / epsvec[1]
-    gg1 = epsvec[0] - 1
-    gg2 = epsvec[1] - 1
-    hh1 = epsvec[0] / (1 - epsvec[0])
-    hh2 = epsvec[1] / (1 - epsvec[1])
-    ii1 = ((1 / Avec[0]) * (((aa1 ** ee1) + (bb1 ** ee1) * (cc1 ** ff1)
-          * (dd1 ** gg1)) ** hh1))
-    ii2 = ((1 / Avec[1]) * (((aa2 ** ee2) + (bb2 ** ee2) * (cc2 ** ff2)
-          * (dd2 ** gg2)) ** hh2))
-    K1path = Ympath[0, :] * ii1
-    K2path = Ympath[1, :] * ii2
-    Kmpath = np.vstack((K1path, K2path))
-    return Kmpath
-
-
-# def get_Lmpath(T, rpath, wpath, Ympath, Kmpath, pmpath, delvec):
-#     '''
-#     Generates vector of labor demand L_m for each industry m
-
-#     Inputs:
-#         params = length 2 tuple, (r, w)
-#         r      = scalar > 0, interest rate
-#         w      = scalar > 0, real wage
-#         Ymvec  = [2,] vector, aggregate output of all goods
-#         Kmvec  = [2,] vector, capital demand in all industries
-#         pmvec  = [2,] vector, prices in each industry
-#         delvec = [2,] vector, model period depreciation rates for all
-#                  industries
-
-#     Functions called: None
-
-#     Objects in function:
-#         Lmvec = [2,] vector, aggregate output of all goods
-
-#     Returns: Lmvec
-#     '''
-#     delmat = np.tile(delvec.reshape((2, 1)), T)
-#     Lmpath = (pmpath * Ympath - (rpath + delmat) * Kmpath) / wpath
-
-#     return Lmpath
-
-
-def get_Lmpath2(Ympath, wpath, pmpath, Avec, gamvec, epsvec):
-    '''
-    Generates vector of labor demand L_m for good m given Y_m, p_m and w
-
-    Inputs:
-        Ympath = [2, T] matrix, time path of aggregate output by
-                 industry
-        wpath  = [T, ] vector, time path of real wage
-        pmpath = [2, T] matrix, time path of industry prices
-        Avec   = [2,] vector, total factor productivity values for all
-                 industries
-        gamvec = [2,] vector, capital shares of income for all
-                 industries
-        epsvec = [2,] vector, elasticities of substitution between
-                 capital and labor for all industries
-
-    Functions called: None
-
-    Objects in function:
-        asdf
-
-    Returns: Lmpath
-    '''
-    numer1 = (1 - gamvec[0]) * Ympath[0,:] * (pmpath[0,:] ** epsvec[0])
-    denom1 = (wpath ** epsvec[0]) * (Avec[0] ** (1 - epsvec[0]))
-    L1path = numer1 / denom1
-    numer2 = (1 - gamvec[1]) * Ympath[1,:] * (pmpath[1,:] ** epsvec[1])
-    denom2 = (wpath ** epsvec[1]) * (Avec[1] ** (1 - epsvec[1]))
-    L2path = numer2 / denom2
-    Lmpath = np.vstack((L1path, L2path))
-    return Lmpath
-
-
-def get_Lmpath2_alt(Kmpath, rpath, wpath, gamvec, epsvec, delvec):
+def get_Lmpath(Kmpath, rpath, wpath, gamvec, epsvec, delvec):
     '''
     Generates vector of labor demand L_m for good m given Y_m, p_m and w
 
@@ -681,55 +490,7 @@ def get_Lmpath2_alt(Kmpath, rpath, wpath, gamvec, epsvec, delvec):
 
 
 
-def get_Yrespath(params, Kpath, Lpath):
-    A, gam, eps = params
-    Ypath = (A * ((gam ** (1 / eps)) * (Kpath ** ((eps - 1) / eps)) +
-            ((1 - gam) ** (1 / eps)) * (Lpath ** ((eps - 1) / eps)))
-            ** (eps / (eps - 1)))
-    return Ypath
-
-
-def get_rnewpath2(params, Kmpath, Ympath, pmpath):
-    Am, gamm, epsm, delm = params
-    rpath = (pmpath * (Am ** ((epsm - 1) / epsm)) *
-            ((gamm * Ympath / Kmpath) ** (1 / epsm)) - delm)
-    return rpath
-
-
-def get_wnewpath2(params, Lpath, Ypath, pmpath):
-    Am, gamm, epsm = params
-    wpath = (pmpath * (Am ** ((epsm - 1) / epsm)) *
-            (((1 - gamm) * Ypath / Lpath) ** (1 / epsm)))
-    return wpath
-
-
-# def get_rnewpath(params, Kpath, Lpath, Ypath, pmpath):
-#     Am, gamm, epsm, delm = params
-#     aa = (epsm - 1) / epsm
-#     bb = 1 / epsm
-#     rpath = ((pmpath / Kpath) * (Ypath - (Am ** aa) *
-#             (((1 - gamm) * Ypath) ** bb) * (Lpath ** aa))) - delm
-#     return rpath
-
-
-# def get_wnewpath(params, Kpath, Lpath, Ypath, pmpath):
-#     Am, gamm, epsm = params
-#     aa = (epsm - 1) / epsm
-#     bb = 1 / epsm
-#     wpath = ((pmpath / Lpath) * (Ypath - (Am ** aa) *
-#             ((gamm * Ypath) ** bb) * (Kpath ** aa)))
-#     return wpath
-
-
-# def get_wnewpath(params, Kpath, Lpath, rpath):
-#     gamm, epsm, delm = params
-#     aa = (1 - gamm) / gamm
-#     bb = 1 / epsm
-#     wpath = (aa ** bb) * ((Kpath / Lpath) ** bb) * (rpath + delm)
-#     return wpath
-
-
-def TPI(params, rpath_init, wpath_init, Km_ss, Ym_ss, Gamma1, cmtilvec, Avec,
+def TP(params, rpath_init, wpath_init, Km_ss, Ym_ss, Gamma1, cmtilvec, Avec,
   gamvec, epsvec, delvec, nvec, graphs):
     '''
     Generates equilibrium time path for all endogenous objects from
@@ -822,93 +583,25 @@ def TPI(params, rpath_init, wpath_init, Km_ss, Ym_ss, Gamma1, cmtilvec, Avec,
     start_time = time.clock()
     (S, T, alpha, beta, sigma, r_ss, w_ss, maxiter, mindist, xi,
         tpi_tol) = params
-    iter_tpi = int(0)
-    dist_tpi = 10.
-    rpath_new = rpath_init
-    wpath_new = wpath_init
 
-    while iter_tpi < maxiter and (dist_tpi >= mindist):
-        iter_tpi += 1
-        rpath_init = xi * rpath_new + (1 - xi) * rpath_init
-        wpath_init = xi * wpath_new + (1 - xi) * wpath_init
-        pm_params = (Avec, gamvec, epsvec, delvec)
-        pmpath = get_pmpath(pm_params, rpath_init, wpath_init)
-        ppath = get_ppath(alpha, pmpath)
-        cbe_params = (S, T, alpha, beta, sigma, tpi_tol)
-        bpath, cpath, cmpath, eulerrpath = get_cbepath(cbe_params,
-            Gamma1, rpath_init, wpath_init, pmpath, ppath, cmtilvec,
-            nvec)
-        Cmpath = get_Cmpath(cmpath[:, :T, :])
-        Ym_params = (T, r_ss, w_ss)
-        Ympath, Kmpath = get_YKmpath2(Ym_params, rpath_init[:T],
-            wpath_init[:T], Km_ss, Cmpath, Avec, gamvec, epsvec, delvec)
-
-        #Ympath = get_Ympath(Ym_params, rpath_init[:T],
-        #         wpath_init[:T], Ym_ss, Cmpath, Avec, gamvec, epsvec,
-        #         delvec)
-        # Ympath = get_Ympath_alt(Ym_params, rpath_init[:T],
-        #          wpath_init[:T], Km_ss, Cmpath, Avec, gamvec, epsvec,
-        #          delvec)
-        # Kmpath = get_Kmpath(Ympath, rpath_init[:T], wpath_init[:T],
-        #          Avec, gamvec, epsvec, delvec)
+    pm_params = (Avec, gamvec, epsvec, delvec)
+    pmpath = get_pmpath(pm_params, rpath_init, wpath_init)
+    ppath = get_ppath(alpha, pmpath)
+    cbe_params = (S, T, alpha, beta, sigma, tpi_tol)
+    bpath, cpath, cmpath, eulerrpath = get_cbepath(cbe_params,
+        Gamma1, rpath_init, wpath_init, pmpath, ppath, cmtilvec,
+        nvec)
+    Cmpath = get_Cmpath(cmpath[:, :T, :])
+    Ym_params = (T, r_ss, w_ss)
+    Ympath, Kmpath = get_YKmpath2(Ym_params, rpath_init[:T],
+        wpath_init[:T], Km_ss, Cmpath, Avec, gamvec, epsvec, delvec)
 
 
-        delmat = np.tile(delvec.reshape((2, 1)), T-2)
-        Impath = Kmpath[:, 1:T-1] - (1 - delmat) * Kmpath[:, :T-2]
+    Lmpath = get_Lmpath2_alt(Kmpath, rpath[:T], wpath[:T], gamvec, epsvec, delvec)
 
-        ResmDiff = (Ympath[:, :T-2] - Cmpath[:, :T-2] - Impath)
-        #print 'The max. absolute error in the RC for this iteration is:'
-        #print np.absolute(ResmDiff).max(axis=1)
-
-        # Ympath, Kmpath = get_YKmpath(rpath_init[:T-1], wpath_init[:T-1],
-        #                  Cmpath, Avec, gamvec, epsvec, delvec)
-        # Lmpath = get_Lmpath(T, rpath_init[:T], wpath_init[:T],
-        #          Ympath, Kmpath, pmpath[:, :T], delvec)
-        Lmpath = get_Lmpath2(Ympath, wpath_init[:T], pmpath[:,:T],
-                 Avec, gamvec, epsvec)
-        # Compute new r and w time paths from residual industry
-        K2respath = bpath[:, :T].sum(axis=0) - Kmpath[0, :]
-        L2respath = nvec.sum() - Lmpath[0,:]
-        # Yres_params = (Avec[1], gamvec[1], epsvec[1])
-        # Y2respath = get_Yrespath(Yres_params, K2respath, L2respath)
-        rpath_new = np.zeros(T+S-1)
-        wpath_new = np.zeros(T+S-1)
-        rnew_params = (Avec[1], gamvec[1], epsvec[1], delvec[1])
-        # rpath_new[:T-1] = get_rnewpath(rnew_params, K2respath,
-        #                   L2respath, Y2respath, pmpath[1, :T-1])
-        rpath_new[:T] = get_rnewpath2(rnew_params, K2respath,
-                        Ympath[1,:], pmpath[1,:T])
-        # rres_params = (Avec[1], gamvec[1], epsvec[1], delvec[1])
-        # rpath_new[:T-1] = get_rrespath(rres_params, K2respath,
-        #                   Y2respath, pmpath[1, :T-1])
-        rpath_new[T:] = rpath_init[-1]
-        wnew_params = (Avec[1], gamvec[1], epsvec[1])
-        wpath_new[:T] = get_wnewpath2(wnew_params, L2respath,
-                        Ympath[1,:], pmpath[1,:T])
-        # wres_params = (Avec[1], gamvec[1], epsvec[1])
-        # wpath_new[:T-1] = get_wrespath(wres_params, L2respath,
-        #                   Y2respath, pmpath[1, :T-1])
-        wpath_new[T:] = wpath_init[-1]
-        # Check the distance of Kpath_new1
-        rwpath_new = np.append(rpath_new[:T], wpath_new[:T])
-        rwpath_init = np.append(rpath_init[:T], wpath_init[:T])
-        dist_tpi = np.absolute((rwpath_new - rwpath_init) /
-                   rwpath_init).max()
-        print ('iter: ', iter_tpi, ', dist: ', dist_tpi, ', max Eul err: ',
-            np.absolute(eulerrpath).max())
-        # plt.plot(rpath_init[:T])
-        # plt.plot(rpath_new[:T])
-        # plt.show()
-        # plt.plot(wpath_init[:T])
-        # plt.plot(wpath_new[:T])
-        # plt.show()
-
-    if iter_tpi == maxiter and dist_tpi > mindist:
-        print 'TPI reached maxiter and did not converge.'
-    elif iter_tpi == maxiter and dist_tpi <= mindist:
-        print 'TPI converged in the last iteration. Should probably increase maxiter_TPI.'
-    rpath = rpath_new
-    wpath = wpath_new
+    
+    rpath = rpath_init
+    wpath = wpath_init
     MCKerrpath = bpath[:, :T].sum(axis=0) - Kmpath.sum(axis=0)
     MCLerrpath = nvec.sum() - Lmpath.sum(axis=0)
     elapsed_time = time.clock() - start_time
@@ -1121,7 +814,7 @@ def TPI_fsolve(guesses, params, Km_ss, Ym_ss, Gamma1, cmtilvec, Avec,
 
     rpath = np.zeros(T+S-1)
     wpath = np.zeros(T+S-1)
-    rpath[:T] = guesses[0: T]
+    rpath[:T] = guesses[0:T]
     wpath[:T] = guesses[T:]
     rpath[T:] = r_ss
     wpath[T:] = w_ss
@@ -1136,26 +829,10 @@ def TPI_fsolve(guesses, params, Km_ss, Ym_ss, Gamma1, cmtilvec, Avec,
     Cmpath = get_Cmpath(cmpath[:, :T, :])
     Ym_params = (T, r_ss, w_ss)
 
-    #Ympath, Kmpath = get_YKmpath2(Ym_params, rpath[:T],
-    #        wpath[:T], Km_ss, Cmpath, Avec, gamvec, epsvec, delvec)
+    Ympath, Kmpath = get_YKmpath(Ym_params, rpath[:T], wpath[:T], Km_ss,
+                      Cmpath, Avec, gamvec, epsvec, delvec)
 
-    #Ympath = get_Ympath(Ym_params, rpath_init[:T],
-    #        wpath_init[:T], Ym_ss, Cmpath, Avec, gamvec, epsvec,
-    #        delvec)
-    Ympath = get_Ympath_alt(Ym_params, rpath[:T],
-             wpath[:T], Km_ss, Cmpath, Avec, gamvec, epsvec,
-             delvec)
-    Kmpath = get_Kmpath(Ympath, rpath[:T], wpath[:T],
-             Avec, gamvec, epsvec, delvec)
-
-
-    # Ympath, Kmpath = get_YKmpath(rpath_init[:T-1], wpath_init[:T-1],
-    #                  Cmpath, Avec, gamvec, epsvec, delvec)
-    # Lmpath = get_Lmpath(T, rpath_init[:T], wpath_init[:T],
-    #          Ympath, Kmpath, pmpath[:, :T], delvec)
-    #Lmpath = get_Lmpath2(Ympath, wpath[:T], pmpath[:,:T],
-    #         Avec, gamvec, epsvec)
-    Lmpath = get_Lmpath2_alt(Kmpath, rpath[:T], wpath[:T], gamvec, epsvec, delvec)
+    Lmpath = get_Lmpath(Kmpath, rpath[:T], wpath[:T], gamvec, epsvec, delvec)
 
     # Check market clearing in each period
     K_market_error = bpath[:, :T].sum(axis=0) - Kmpath[:, :].sum(axis=0)


### PR DESCRIPTION
This pull request:
- Deletes alternative, unused versions of get_Ympath, get_Kmpath, get_Lmpath
- Deletes convergence method
- Renames TPI function as TP- it is called after fsolve to get all the other endogenous variables along the time path (TPI_fsolve just returns rpath, wpath).  We might want to consolidate this later - some redundancy between TP and TPI_fsolve.

